### PR TITLE
Fix for English Angevine mission.

### DIFF
--- a/events/ME_England_Events.txt
+++ b/events/ME_England_Events.txt
@@ -72,6 +72,15 @@ country_event = { #A new Order
 				cede_province = ROOT
 			}
 		}
+
+		4694 = {
+			if = {
+				limit = {
+					owned_by = FRA
+				}
+				cede_province = ROOT
+			}
+		}
 		set_country_flag = ENG_Angevin_Missions
 		set_country_flag = formed_great_britain_flag
 		set_country_flag = formed_england_flag


### PR DESCRIPTION
My first contribution to ME :3c

Fixes angevine mission event which cedes provinces to england after subjugating france.
1.30 added foix (4694) to the pyrenese area. Notable problem could be that labadour is not cede'd either and if the player lost this province before and subjugated france, theyd be incapable of completing the mission. I would suggest changing the whole thing to saying cede the pyrenese area to root but I went with what was going on already