### PR TITLE
Corsica Non-DLC

### DIFF
--- a/common/event_modifiers/ME_Corsica_Modifiers.txt
+++ b/common/event_modifiers/ME_Corsica_Modifiers.txt
@@ -21,6 +21,10 @@ cor_mare_piratae = {
 	privateer_efficiency = 0.20
 	global_ship_cost = -0.10
 }
+cor_mare_piratae_nodlc = {
+	global_ship_trade_power = 0.20
+	global_ship_cost = -0.10
+}
 #4th slot
 cor_urban_development = {
 	development_cost = -0.10

--- a/localisation/ME_Corsica_l_english.yml
+++ b/localisation/ME_Corsica_l_english.yml
@@ -47,6 +47,7 @@
  #3rd slot
  cor_naval_strategies: "Naval Strategies"
  cor_mare_piratae: "Mare Piratae"
+ cor_mare_piratae_nodlc: "Mare Piratae"
  #4th slot
  cor_urban_development: "Urban Development"
  cor_school_of_florence: "School of Florence"

--- a/missions/ME_Corsica_Missions.txt
+++ b/missions/ME_Corsica_Missions.txt
@@ -281,7 +281,10 @@ corsica_missions_3 = {
 			}
 			else = {
 				add_prestige = 10
-				add_power_projection = 10
+				add_power_projection = {
+					type = mission_rewards_power_projection
+					amount = 10
+				}
 			}
 			corsica_sardinia_area = {
 				limit = {
@@ -464,7 +467,7 @@ corsica_missions_4 = {
 			add_years_of_income = 2
 			capital_scope = {
 				add_province_modifier = {
-					name = COR_urban_development
+					name = cor_urban_development
 					duration = -1
 				}
 			}

--- a/missions/ME_Corsica_Missions.txt
+++ b/missions/ME_Corsica_Missions.txt
@@ -29,6 +29,12 @@ corsica_missions_1 = {
 				}
 			}
 			else = {
+				1298 = {
+					trade_share = {
+						country = ROOT
+						share = 15
+					}
+				}
 			}
 		}
 		effect = {
@@ -104,7 +110,18 @@ corsica_missions_2 = {
 					limit = {
 						is_subject = yes
 					}
-					
+					calc_true_if = {
+						amount = 2
+						all_country = {
+							OR = {
+								has_opinion = {
+									who = ROOT
+									value = 80
+								}
+								alliance_with = ROOT
+							}
+						}
+					}
 				}
 				else = {
 					stability = 1
@@ -263,8 +280,8 @@ corsica_missions_3 = {
 				country_event = { id = ME_Corsica_Events.1 }
 			}
 			else = {
-				add_stability = 1
-				add_prestige = 5
+				add_prestige = 10
+				add_power_projection = 10
 			}
 			corsica_sardinia_area = {
 				limit = {
@@ -401,10 +418,21 @@ corsica_missions_3 = {
 		}
 		effect = {
 			add_prestige = 25
-			add_country_modifier = {
-				name = cor_mare_piratae
-				duration = 10950
-			}	
+			if = {
+				limit = {
+					has_dlc = "Golden Century"
+				}
+				add_country_modifier = {
+					name = cor_mare_piratae
+					duration = 10950
+				}
+			}
+			else = {
+				add_country_modifier = {
+					name = cor_mare_piratae_nodlc
+					duration = 10950
+				}
+			}
 		}
 	}
 }

--- a/missions/ME_Corsica_Missions.txt
+++ b/missions/ME_Corsica_Missions.txt
@@ -423,7 +423,12 @@ corsica_missions_3 = {
 			add_prestige = 25
 			if = {
 				limit = {
-					has_dlc = "Golden Century"
+					OR = {
+						has_dlc = "Wealth of Nations"
+						has_dlc = "El Dorado"
+						has_dlc = "Mare Nostrum"
+						has_dlc = "Golden Century"
+					}
 				}
 				add_country_modifier = {
 					name = cor_mare_piratae


### PR DESCRIPTION
Non DLC triggers/effects:
independent corsica can have a reward of +10 prestige and +10 power projection
genoese piracy: replace privateer with have 15% trade share in genoa
seek support from abroad: at least 2 countries have 80 opinion of corsica or are allied to corsica
and mare piratae can give +20% ship trade power